### PR TITLE
auditdistd: chase capability.h to capsicum.h renaming

### DIFF
--- a/bin/auditdistd/sandbox.c
+++ b/bin/auditdistd/sandbox.c
@@ -34,7 +34,7 @@
 #include <sys/jail.h>
 #endif
 #ifdef HAVE_CAP_ENTER
-#include <sys/capability.h>
+#include <sys/capsicum.h>
 #endif
 
 #include <errno.h>


### PR DESCRIPTION
In FreeBSD SVN rev 263232 sys/capability.h was renamed to sys/capsicum.h
to avoid conflicts with capability.h found on other operating systems.
