### PR TITLE
praudit: Restrict file descriptors in Capsicum sandbox

### DIFF
--- a/config/config.h.in
+++ b/config/config.h.in
@@ -15,6 +15,9 @@
 /* Define to 1 if you have the `bzero' function. */
 #undef HAVE_BZERO
 
+/* Define to 1 if you have the <capsicum_helpers.h> header file. */
+#undef HAVE_CAPSICUM_HELPERS_H
+
 /* Define to 1 if you have the `cap_enter' function. */
 #undef HAVE_CAP_ENTER
 

--- a/configure
+++ b/configure
@@ -12878,7 +12878,7 @@ $as_echo "#define HAVE_SYS_WAIT_H 1" >>confdefs.h
 
 fi
 
-for ac_header in mach/mach.h stdint.h pthread_np.h printf.h
+for ac_header in mach/mach.h stdint.h pthread_np.h printf.h capsicum_helpers.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AC_SEARCH_LIBS(pidfile_open, util)
 # Checks for header files.
 AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
-AC_CHECK_HEADERS([mach/mach.h stdint.h pthread_np.h printf.h])
+AC_CHECK_HEADERS([mach/mach.h stdint.h pthread_np.h printf.h capsicum_helpers.h])
 
 AC_DEFINE([_GNU_SOURCE],,[Use extended API on platforms that require it])
 


### PR DESCRIPTION
Add capsicum_helpers.h detection to configure and provide a
compatability fallback (sourced from FreeBSD).