### PR TITLE
Fix compilation on Ubuntu Linux

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -43,3 +43,9 @@ directory the correct libbsm is used:
     make
     make install
     LD_LIBRARY_PATH=/home/rwatson/openbsm/libbsm ; export LD_LIBRARY_PATH
+
+In order to compile auditdistd it might be necessary to get yacc or a
+compatible program. Also, it is necessary to have a lexical analyser generator
+such as flex. The following appears to work on Ubuntu:
+
+    sudo apt-get install byacc flex

--- a/bin/auditdistd/sandbox.c
+++ b/bin/auditdistd/sandbox.c
@@ -46,6 +46,14 @@
 #include <strings.h>
 #include <unistd.h>
 
+/*
+ * This header is conditionally included in Linux because getgrouplist() and
+ * setgroups() isn't defined in unistd.h.
+ */
+#if defined(__linux__)
+#include <grp.h>
+#endif
+
 #include "pjdlog.h"
 #include "sandbox.h"
 

--- a/bin/auditdistd/synch.h
+++ b/bin/auditdistd/synch.h
@@ -86,12 +86,14 @@ mtx_unlock(pthread_mutex_t *lock)
 	error = pthread_mutex_unlock(lock);
 	PJDLOG_ASSERT(error == 0);
 }
+#if defined(HAVE_PTHREAD_MUTEX_ISOWNED_NP)
 static __inline bool
 mtx_owned(pthread_mutex_t *lock)
 {
 
 	return (pthread_mutex_isowned_np(lock) != 0);
 }
+#endif
 
 static __inline void
 rw_init(pthread_rwlock_t *lock)

--- a/configure
+++ b/configure
@@ -13977,7 +13977,7 @@ fi
 fi
 done
 
-for ac_func in arc4random arc4random_buf bzero cap_enter clock_gettime closefrom faccessat fdopendir fstatat ftruncate getresgid getresuid gettimeofday inet_ntoa jail kqueue memset openat pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_mutex_lock renameat setproctitle sigtimedwait strchr strerror strlcat strlcpy strndup strrchr strstr strtol strtoul unlinkat vis
+for ac_func in arc4random arc4random_buf bzero cap_enter clock_gettime closefrom faccessat fdopendir fstatat ftruncate getresgid getresuid gettimeofday inet_ntoa jail kqueue memset openat pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_mutex_isowned_np pthread_mutex_lock renameat setproctitle sigtimedwait strchr strerror strlcat strlcpy strndup strrchr strstr strtol strtoul unlinkat vis
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -100,7 +100,7 @@ AC_FUNC_MKTIME
 AC_TYPE_SIGNAL
 AC_FUNC_STAT
 AC_FUNC_STRFTIME
-AC_CHECK_FUNCS([arc4random arc4random_buf bzero cap_enter clock_gettime closefrom faccessat fdopendir fstatat ftruncate getresgid getresuid gettimeofday inet_ntoa jail kqueue memset openat pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_mutex_lock renameat setproctitle sigtimedwait strchr strerror strlcat strlcpy strndup strrchr strstr strtol strtoul unlinkat vis])
+AC_CHECK_FUNCS([arc4random arc4random_buf bzero cap_enter clock_gettime closefrom faccessat fdopendir fstatat ftruncate getresgid getresuid gettimeofday inet_ntoa jail kqueue memset openat pthread_cond_timedwait_relative_np pthread_condattr_setclock pthread_mutex_isowned_np pthread_mutex_lock renameat setproctitle sigtimedwait strchr strerror strlcat strlcpy strndup strrchr strstr strtol strtoul unlinkat vis])
 
 # sys/queue.h exists on most systems, but its capabilities vary a great deal.
 # test for LIST_FIRST and TAILQ_FOREACH_SAFE, which appears to not exist in


### PR DESCRIPTION
This PR solves a couple of problems I stumbled upon as I was building OpenBSM on Ubuntu 17.04:

1. `getgrouplist()` is not defined in `unistd.h` on Linux as it is on FreeBSD. It can be found in `grp.h` though.
2.  `pthread_mutex_isowned_np` is not available on Linux. It is never used, however, so it is possible to ignore it when compiling on Linux.
3. Yacc and flex (or any other compatible replacements) are required for the compilation to succeed. Hence, I added a small note to the INSTALL file about it. 
 
   At the moment the note suggests to install `bison`. Should I change it to `byacc`?