### PR TITLE
Fix style and typos in comments

### DIFF
--- a/libauditd/auditd_lib.c
+++ b/libauditd/auditd_lib.c
@@ -496,9 +496,9 @@ auditd_expire_trails(int (*warn_expired)(char *))
 			/*
 			 * If the time stamp is older than Jan 1, 2000 then
 			 * update the mtime of the trail file to the current
-			 * time. This is so we don't prematurely remove a trail
+			 * time.  This is so we don't prematurely remove a trail
 			 * file that was created while the system clock reset
-			 * to the * "beginning of time" but later the system
+			 * to the "beginning of time" but later the system
 			 * clock is set to the correct current time.
 			 */
 			if (current_time >= JAN_01_2000 &&

--- a/sys/bsm/audit.h
+++ b/sys/bsm/audit.h
@@ -46,7 +46,7 @@
 #define	MIN_AUDIT_FILE_SIZE	(512 * 1024)
 
 /*
- * Minimum noumber of free blocks on the filesystem containing the audit
+ * Minimum number of free blocks on the filesystem containing the audit
  * log necessary to avoid a hard log rotation. DO NOT SET THIS VALUE TO 0
  * as the kernel does an unsigned compare, plus we want to leave a few blocks
  * free so userspace can terminate the log, etc.
@@ -249,14 +249,14 @@ typedef	struct au_token	token_t;
 /*
  * Kernel audit queue control parameters:
  * 			Default:		Maximum:
- * 	aq_hiwater:	AQ_HIWATER (100)	AQ_MAXHIGH (10000) 
+ * 	aq_hiwater:	AQ_HIWATER (100)	AQ_MAXHIGH (10000)
  * 	aq_lowater:	AQ_LOWATER (10)		<aq_hiwater
  * 	aq_bufsz:	AQ_BUFSZ (32767)	AQ_MAXBUFSZ (1048576)
- * 	aq_delay:	20			20000 (not used) 
+ * 	aq_delay:	20			20000 (not used)
  */
 struct au_qctrl {
 	int	aq_hiwater;	/* Max # of audit recs in queue when */
-				/* threads with new ARs get blocked. */ 
+				/* threads with new ARs get blocked. */
 
 	int	aq_lowater;	/* # of audit recs in queue when */
 				/* blocked threads get unblocked. */


### PR DESCRIPTION
I removed an unnecessary asterisk and added the second space after a period.