### PR TITLE
Update m4 in Directory list

### DIFF
--- a/README
+++ b/README
@@ -34,6 +34,7 @@ OpenBSM consists of several directories:
     libauditd/     Common audit management functions for auditd and launchd
     libbsm/        Implementation of BSM library interfaces and man pages
     man/           System call and configuration file man pages
+    m4/            Input files for m4 macro text processor 
     modules/       Directory for auditfilterd module source
     sys/           System header files for BSM
     test/          Test token sets and geneneration program

--- a/bin/auditd/audit_warn.c
+++ b/bin/auditd/audit_warn.c
@@ -114,7 +114,7 @@ audit_warn_auditoff(void)
 }
 
 /*
- * Indicate that a trail file has been closed, so can now be post-processed.
+ * Indicates that a trail file has been closed, so can now be post-processed.
  */
 int
 audit_warn_closefile(char *filename)
@@ -129,7 +129,7 @@ audit_warn_closefile(char *filename)
 }
 
 /*
- * Indicates that the audit deammn is already running
+ * Indicates that the audit daemon is already running
  */
 int
 audit_warn_ebusy(void)
@@ -191,7 +191,7 @@ audit_warn_nostart(void)
 }
 
 /*
- * Indicaes that an error occrred during the orderly shutdown of the audit
+ * Indicates that an error occurred during the orderly shutdown of the audit
  * daemon.
  */
 int
@@ -221,7 +221,7 @@ audit_warn_soft(char *filename)
 }
 
 /*
- * Indicates that the temporary audit file already exists indicating a fatal
+ * Indicates that the temporary audit file already exists resulting in a fatal
  * error.
  */
 int


### PR DESCRIPTION
The `README` was missing the folder `m4` in the list of directories in the base tree. This PR updates the list.
@csjayp @cbrueffer 