### PR TITLE
Add a missing ai_flags to the struct auditinfo_addr

### DIFF
--- a/man/getaudit.2
+++ b/man/getaudit.2
@@ -24,7 +24,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd October 19, 2008
+.Dd March 14, 2018
 .Dt GETAUDIT 2
 .Os
 .Sh NAME
@@ -116,6 +116,7 @@ struct auditinfo_addr {
 	au_mask_t       ai_mask;        /* Audit masks. */
 	au_tid_addr_t   ai_termid;      /* Terminal ID. */
 	au_asid_t       ai_asid;        /* Audit session ID. */
+	au_asflgs_t     ai_flags;       /* Audit session flags. */
 };
 typedef struct auditinfo_addr   auditinfo_addr_t;
 .Ed


### PR DESCRIPTION
The struct auditinfo_addr structure, which is defined in sys/bsm/audit.h, has a field called ai_flags, which is not included in the manual page.