### PR TITLE
Correct the success return value for au_read_rec() in au_io.3

### DIFF
--- a/libbsm/au_io.3
+++ b/libbsm/au_io.3
@@ -129,14 +129,14 @@ would be used to free the record buffer.
 Finally, the source stream would be closed by a call to
 .Xr fclose 3 .
 .Sh RETURN VALUES
-The
+The function
 .Fn au_fetch_tok
-and
+returns 0, while the function
 .Fn au_read_rec
-functions
-return 0 on success, or \-1 on failure along with additional error information
-returned via
-.Va errno .
+returns the number of bytes read, on success. Both functions return \-1 on
+failure with
+.Va errno
+set appropriately.
 .Sh SEE ALSO
 .Xr free 3 ,
 .Xr libbsm 3


### PR DESCRIPTION
The manpage of `au_io.3` shows the incorrect success return value of `au_read_rec()` as 0, since it returns the number of bytes read from a file stream.
Correct implementation done here: [bsmtrace/bsm.c](https://github.com/openbsm/bsmtrace/blob/master/bsm.c#L564)
``` C
while ((reclen = au_read_rec(fp, &bsm_rec)) != -1) {
        ....
        bd.br_raw_len = reclen;
        ....
}
```
Here, on success, the function returns no. of bytes which is stored in `reclen`.
