### PR TITLE
corrected size of 'File Access Mode' field of attribute token

### DIFF
--- a/man/audit.log.5
+++ b/man/audit.log.5
@@ -470,7 +470,7 @@ or
 .Bl -column -offset 3n ".No Terminal Address Type/Length" ".No N bytes + 1 NUL"
 .It Sy "Field	Bytes	Description"
 .It "Token ID	1 byte	Token ID"
-.It "File Access Mode	1 byte	mode_t associated with file"
+.It "File Access Mode	4 bytes	mode_t associated with file"
 .It "Owner User ID	4 bytes	uid_t associated with file"
 .It "Owner Group ID	4 bytes	gid_t associated with file"
 .It "File System ID	4 bytes	fsid_t associated with file"


### PR DESCRIPTION
Hi there,

the attribute token has a field `File Access Mode`. The manpage for audit.log claims its size is 1 byte. This field has an actual size of 4 bytes, as used in `au_to_attr32()`. This PR fixes this mismatch.

Cheers,
tpltnt