### PR TITLE
fixed length of 'Terminal Address Type/Length' in expanded process token

### DIFF
--- a/man/audit.log.5
+++ b/man/audit.log.5
@@ -330,7 +330,7 @@ or
 .It "Process ID	4 bytes	Process ID"
 .It "Session ID	4 bytes	Audit session ID"
 .It "Terminal Port ID	4/8 bytes	Terminal port ID (32/64-bits)"
-.It "Terminal Address Type/Length	1 byte	Length of machine address"
+.It "Terminal Address Type/Length	4 bytes	Length of machine address"
 .It "Terminal Machine Address	4 bytes	IPv4 or IPv6 address of machine"
 .El
 .Ss Return Token


### PR DESCRIPTION
Hi there,

the expanded process token has a field `Terminal Address Type/Length`. The manpage for audit.log claims its size is 1 byte. This field has an actual size of 4 bytes, as used in `au_to_process32_ex()`. This PR fixes this mismatch.

Cheers,
tpltnt