### PR TITLE
Correct the final return status of praudit to 0

### DIFF
--- a/bin/praudit/praudit.1
+++ b/bin/praudit/praudit.1
@@ -25,7 +25,7 @@
 .\" IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd August 4, 2009
+.Dd June 11, 2018
 .Dt PRAUDIT 1
 .Os
 .Sh NAME
@@ -88,6 +88,11 @@ Events are displayed as per their descriptions given in
 .Pa /etc/security/audit_event ;
 UIDs and GIDs are expanded to their names;
 dates and times are displayed in human-readable format.
+.Sh EXIT STATUS
+The
+.Nm
+utility exits 0 on success,
+and 1 if an error occurs.
 .Sh FILES
 .Bl -tag -width ".Pa /etc/security/audit_control" -compact
 .It Pa /etc/security/audit_class

--- a/bin/praudit/praudit.1
+++ b/bin/praudit/praudit.1
@@ -89,10 +89,7 @@ Events are displayed as per their descriptions given in
 UIDs and GIDs are expanded to their names;
 dates and times are displayed in human-readable format.
 .Sh EXIT STATUS
-The
-.Nm
-utility exits 0 on success,
-and 1 if an error occurs.
+.Ex -std
 .Sh FILES
 .Bl -tag -width ".Pa /etc/security/audit_control" -compact
 .It Pa /etc/security/audit_class

--- a/bin/praudit/praudit.c
+++ b/bin/praudit/praudit.c
@@ -245,5 +245,5 @@ main(int argc, char **argv)
 	if (oflags & AU_OFLAG_XML)
 		au_print_xml_footer(stdout);
 
-	return (1);
+	return (0);
 }


### PR DESCRIPTION
`praudit` always returns 1 as a return value which signifies unsuccessful execution.

Prior to the change
``` bash
$ praudit /var/audit/20180610224353.20180610224353. ; echo $?
header,56,11,audit startup,0,Sun Jun 10 22:43:53 2018, + 638 msec
text,auditd::Audit startup
return,success,0
trailer,56
1
```
Even though the trail conversion is successful, this shows a non-successful return. 

Post the change
``` bash
$ praudit /var/audit/20180610224353.20180610224353. ; echo $?
header,56,11,audit startup,0,Sun Jun 10 22:43:53 2018, + 638 msec
text,auditd::Audit startup
return,success,0
trailer,56
0
```
Now the return value is corrected.

Note:
This bug fails the regression tests developed for `praudit(1)` using `atf-sh(3)`. 
Here: [https://reviews.freebsd.org/D15751#inline-95852](https://reviews.freebsd.org/D15751#inline-95852)