### PR TITLE
Fix CPU spinning issue with empty trail and make -p option the default default behaviour

### DIFF
--- a/bin/praudit/praudit.1
+++ b/bin/praudit/praudit.1
@@ -25,7 +25,7 @@
 .\" IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd June 11, 2018
+.Dd June 18, 2018
 .Dt PRAUDIT 1
 .Os
 .Sh NAME
@@ -33,7 +33,7 @@
 .Nd "print the contents of audit trail files"
 .Sh SYNOPSIS
 .Nm
-.Op Fl lnpx
+.Op Fl lnx
 .Op Fl r | s
 .Op Fl d Ar del
 .Op Ar
@@ -42,6 +42,10 @@ The
 .Nm
 utility prints the contents of the audit trail files to the standard output in
 human-readable form.
+.Nm
+by default syncs to the start of next legitimate record if the initial part of
+.Ar file
+is corrupted.
 If no
 .Ar file
 argument is specified, the standard input is used
@@ -59,15 +63,6 @@ every token is displayed on a different line.
 .It Fl n
 Do not convert user and group IDs to their names but leave in their
 numeric forms.
-.It Fl p
-Specify this option if input to
-.Nm
-is piped from the
-.Xr tail 1
-utility.
-This causes
-.Nm
-to sync to the start of the next record.
 .It Fl r
 Prints the records in their raw, numeric form.
 This option is exclusive from


### PR DESCRIPTION
This PR introduces following changes
* Enforce strict `exit(1)` return value at all reasonable failures
* Remove `-p` option. Instead, make its behavior default.
* Introduce a check for empty audit trail [Spinning CPU issue]

`praudit -p` syncs to the beginning of next legitimate audit record while ignoring the corrupted (incomplete) part. While the `praudit` default option simply exits without even looking ahead. This behavior can cause uncertain decoding of audit trails which were say, picked up from the beginning of an event.

Also, the code here:  [When -p option is enabled]
``` C
do {
	type = fgetc(fp);
} while(type != AUT_HEADER32);
ungetc(type, fp);
```
Looks for next HEADER token. For an empty trail, with current "-p" option, this causes an infinite loop and the CPU starts shouting.

### Test Plan
``` bash
$ touch emptyfile
$ praudit emptyfile
 File is empty
$ praudit emptyfile; echo $?
 File is empty
 1
```
Introduce a corrupted file
``` bash
$ cat trail
Some random text in the beginning to make it corrupted
  �[S��-domain-type-	protocol$)7t�
'�q
$ praudit trail  # Earlier this could only be done with a -p option
header,113,11,socket(2),0,Mon Jun 11 10:50:20 2018, + 648 msec
argument,1,0x1c,domain
argument,2,0x2,type
argument,3,0x0,protocol
subject,root,root,wheel,root,0,10551,4724,37636,10.0.2.2
return,success,3
trailer,113
```