### PR TITLE
auditd(8): register signal handlers interrutibly

### DIFF
--- a/bin/auditd/auditd.c
+++ b/bin/auditd/auditd.c
@@ -415,27 +415,35 @@ close_all(void)
 static int
 register_daemon(void)
 {
+	struct sigaction action;
 	FILE * pidfile;
 	int fd;
 	pid_t pid;
 
 	/* Set up the signal hander. */
-	if (signal(SIGTERM, auditd_relay_signal) == SIG_ERR) {
+	action.sa_handler = auditd_relay_signal;
+	/*
+	 * sa_flags must not include SA_RESTART, so that read(2) will be
+	 * interruptible in auditd_wait_for_events
+	 */
+	action.sa_flags = 0;
+	sigemptyset(&action.sa_mask);
+	if (sigaction(SIGTERM, &action, NULL) != 0) {
 		auditd_log_err(
 		    "Could not set signal handler for SIGTERM");
 		fail_exit();
 	}
-	if (signal(SIGCHLD, auditd_relay_signal) == SIG_ERR) {
+	if (sigaction(SIGCHLD, &action, NULL) != 0) {
 		auditd_log_err(
 		    "Could not set signal handler for SIGCHLD");
 		fail_exit();
 	}
-	if (signal(SIGHUP, auditd_relay_signal) == SIG_ERR) {
+	if (sigaction(SIGHUP, &action, NULL) != 0) {
 		auditd_log_err(
 		    "Could not set signal handler for SIGHUP");
 		fail_exit();
 	}
-	if (signal(SIGALRM, auditd_relay_signal) == SIG_ERR) {
+	if (sigaction(SIGALRM, &action, NULL) != 0) {
 		auditd_log_err(
 		    "Could not set signal handler for SIGALRM");
 		fail_exit();


### PR DESCRIPTION
auditd_wait_for_events() relies on read(2) being interrupted by signals,
but it registers signal handlers with signal(3), which sets SA_RESTART.
That breaks asynchronous signal handling.  It means that signals don't
actually get handled until after an audit(8) trigger is received.
Symptoms include:

* Sending SIGTERM to auditd doesn't kill it right away; you must send
  SIGTERM and then send a trigger with auditon(2).
* Same with SIGHUP
* Zombie child processes don't get reaped until auditd receives a trigger
  sent by auditon. This includes children created by expiring audit trails
  at auditd startup.

Fix by using sigaction(2) instead of signal(3).

Fixes #34