### PR TITLE
Don't overflow kern.maxproc during startup

### DIFF
--- a/bin/auditd/auditd.h
+++ b/bin/auditd/auditd.h
@@ -94,7 +94,6 @@ void	auditd_wait_for_events(void);
 void	auditd_relay_signal(int signal);
 void	auditd_terminate(void);
 int	auditd_config_controls(void);
-void	auditd_reap_children(void);
 
 
 #endif /* !_AUDITD_H_ */

--- a/bin/auditd/auditd_darwin.c
+++ b/bin/auditd/auditd_darwin.c
@@ -395,10 +395,6 @@ auditd_combined_server(mach_msg_header_t *InHeadP, mach_msg_header_t *OutHeadP)
 			auditd_terminate();
 			/* Not reached. */
 
-		case SIGCHLD:
-			auditd_reap_children();
-			return (TRUE);
-
 		case SIGHUP:
 			auditd_config_controls();
 			return (TRUE);

--- a/bin/auditd/auditd_fbsd.c
+++ b/bin/auditd/auditd_fbsd.c
@@ -57,7 +57,6 @@ static int	auditing_state = AUD_STATE_INIT;
  */
 static int	max_idletime = 0;
 
-static int	sigchlds, sigchlds_handled;
 static int	sighups, sighups_handled;
 static int	sigterms, sigterms_handled;
 static int	sigalrms, sigalrms_handled;
@@ -231,10 +230,6 @@ auditd_wait_for_events(void)
 			auditd_terminate();
 			/* not reached */ 
 		}
- 		if (sigchlds != sigchlds_handled) {
-			sigchlds_handled = sigchlds;
-			auditd_reap_children();
-		}
 		if (sighups != sighups_handled) {
 			auditd_log_debug("%s: SIGHUP", __FUNCTION__);
 			sighups_handled = sighups;
@@ -264,8 +259,6 @@ auditd_relay_signal(int signal)
                 sighups++;
         if (signal == SIGTERM)
                 sigterms++;
-        if (signal == SIGCHLD)
-                sigchlds++;
 	if (signal == SIGALRM)
 		sigalrms++;
 }


### PR DESCRIPTION
auditd(8) invokes /var/security/audit_warn every time it expires an
audit trail.  During startup, it can expire thousands.  It doesn't reap
any of these children until after startup is complete.  That can reach
the kern.maxproc process limit, DOSing the system.

Fix this bug by setting SA_NOCLDWAIT for the SIGCHLD handler, so the
system won't create any zombie processes in the first place.  The
downside is that syslog(3) will no longer log an error if the
/etc/security/audit_warn script fails.

Fixes #35