### PR TITLE
Log a better error when no hostname is set in audit_control

### DIFF
--- a/libauditd/auditd_lib.c
+++ b/libauditd/auditd_lib.c
@@ -261,7 +261,8 @@ auditd_set_host(void)
 	struct auditinfo_addr aia;
 	int error, ret = ADE_NOERR;
 
-	if (getachost(auditd_host, sizeof(auditd_host)) != 0) {
+	if ((getachost(auditd_host, sizeof(auditd_host)) != 0) ||
+	    ((auditd_hostlen = strlen(auditd_host)) == 0)) {
 		ret = ADE_PARSE;
 
 		/*
@@ -278,7 +279,6 @@ auditd_set_host(void)
 			ret = ADE_AUDITON;
 		return (ret);
 	}
-	auditd_hostlen = strlen(auditd_host);
 	error = getaddrinfo(auditd_host, NULL, NULL, &res);
 	if (error)
 		return (ADE_GETADDR);


### PR DESCRIPTION
When no hostname is set in /etc/security/audit_control, auditd should
log a warning saying so.  Such a warning is already included in auditd,
but it's currently dead code since auditd_set_host will never return
ADE_PARSE.  Fix auditd_set_host to better handle this situation.