### PR TITLE
Reap children before entering main event loop

### DIFF
--- a/bin/auditd/audit_warn.c
+++ b/bin/auditd/audit_warn.c
@@ -65,6 +65,7 @@ auditwarnlog(char *args[])
 	/*
 	 * Parent.
 	 */
+	auditd_check_and_reap();
 	return (0);
 }
 

--- a/bin/auditd/auditd.h
+++ b/bin/auditd/auditd.h
@@ -96,5 +96,6 @@ void	auditd_terminate(void);
 int	auditd_config_controls(void);
 void	auditd_reap_children(void);
 
+void	auditd_check_and_reap(void);
 
 #endif /* !_AUDITD_H_ */

--- a/bin/auditd/auditd_darwin.c
+++ b/bin/auditd/auditd_darwin.c
@@ -480,3 +480,9 @@ auditd_relay_signal(int signal)
 	mach_msg(&(msg.header), MACH_SEND_MSG|MACH_SEND_TIMEOUT, sizeof(msg),
 	    0, MACH_PORT_NULL, MACH_MSG_TIMEOUT_NONE, MACH_PORT_NULL);
 }
+
+void
+auditd_check_and_reap(void)
+{
+
+}

--- a/bin/auditd/auditd_fbsd.c
+++ b/bin/auditd/auditd_fbsd.c
@@ -270,3 +270,20 @@ auditd_relay_signal(int signal)
 		sigalrms++;
 }
 
+/*
+ * We call auditd_check_and_reap() after the calls to fork() and exec()
+ * when running the audit_warn script to make sure we do not get a huge
+ * backlog of zombie processes when expiring large volumes of audit trails.
+ *
+ * Since this occurs upon reception of the signal in darwin, we only need to
+ * implement this for freebsd. In darwin it's a no-op
+ */
+void
+auditd_check_and_reap(void)
+{
+
+	if ((sigchlds - sigchlds_handled) > 100) {
+		sigchlds_handled = sigchlds;
+		auditd_reap_children();
+	}
+}


### PR DESCRIPTION
In the event we have thousands of audit trails to expire, we go
through and expire each one, executing the audit_warn script. We
do not reap these children until we enter the main event loop.

This change adds a reap check right after the fork/exec operations,
if we have over 100 child processes that are waiting to be reaped,
do it. This hopefully fixes a denial of service condition when
starting up with many audit trail files.

In collaboration with:	asomers
Issue:	#35