### PR TITLE
Fix "Got unknown trigger" warning after invoking audit_warn

### DIFF
--- a/bin/auditd/auditd_fbsd.c
+++ b/bin/auditd/auditd_fbsd.c
@@ -241,7 +241,7 @@ auditd_wait_for_events(void)
 			auditd_config_controls();
 		}
 
-		if ((num == -1) && (errno == EINTR))
+		if (num == -1)
 			continue;
 		if (num == 0) {
 			auditd_log_err("%s: read EOF", __FUNCTION__);


### PR DESCRIPTION
By fixing read(2) interruptibility, d060887 revealed another bug in
auditd_wait_for_events. When read is interrupted by SIGCHLD,
auditd_reap_children will always return with errno set to ECHILD. But
auditd_wait_for_events checks errno after that point, expecting it to be
unchanged since read. As a result, it calls auditd_handle_trigger with
bogus stack garbage. The result is the error message Got unknown trigger
48.  Fix by simply ignoring errno at that point; there's only one value
it could've possibly had, thanks to the check up above.

Fixes #44