### PR TITLE
Add auditing event identifiers for further FreeBSD syscalls:

### DIFF
--- a/etc/audit_event
+++ b/etc/audit_event
@@ -610,6 +610,9 @@
 43260:AUE_GETUUID:getuuid(2):ip
 43261:AUE_LGETUUID:lgetuuid(2):ip
 43262:AUE_EXECVEAT:execveat(2):pc,ex
+43263:AUE_GETCRED:getcred(2):pc
+43264:AUE_SETCRED:setcred(2):pc
+43265:AUE_REVERTCRED:revertcred(2):pc
 #
 # Solaris userspace events.
 #

--- a/sys/bsm/audit_kevents.h
+++ b/sys/bsm/audit_kevents.h
@@ -652,6 +652,9 @@
 #define	AUE_GETUUID		43260	/* CADETS. */
 #define	AUE_LGETUUID		43261	/* CADETS. */
 #define	AUE_EXECVEAT		43262	/* FreeBSD/Linux. */
+#define	AUE_GETCRED		43263	/* FreeBSD-specific. */
+#define	AUE_SETCRED		43264	/* FreeBSD-specific. */
+#define	AUE_REVERTCRED		43265	/* FreeBSD-specific. */
 
 /*
  * Darwin BSM uses a number of AUE_O_* definitions, which are aliased to the


### PR DESCRIPTION
getcred(2)
setcred(2)
revertcred(2)