### PR TITLE
Fix leading '.' character in audit trail names

### DIFF
--- a/libauditd/auditd_lib.c
+++ b/libauditd/auditd_lib.c
@@ -193,7 +193,7 @@ affixdir(char *name, struct dir_ent *dirent)
 	/*
 	 * If the host is set then also add the hostname to the filename.
 	 */
-	if (auditd_hostlen != -1)
+	if (auditd_hostlen > 0)
 		asprintf(&fn, "%s/%s.%s", dirent->dirname, name, auditd_host);
 	else
 		asprintf(&fn, "%s/%s", dirent->dirname, name);


### PR DESCRIPTION
From pjd's FreeBSD commit (r342873)

Log:

In r316006 the getstrfromtype_locked() function was modified to return
an empty string, instead of NULL, if an entry is missing in the audit_control
file. Because of that change the getachost() function started to return
success even if the host name was not defined in the audit_control.
This in turn led to auditd_hostlen always being set (for an empty host it was
set to 0). If auditd_hostlen was not equal to -1 we were trying to append
the host name to trail file name. All this led to situation where when host
name is not defined in audit_control, auditd will create trail files with
a leading '.', which breaks auditdistd as it doesn't work with longer audit
trail file names.

Fix this by appending host name to the trail file name only if the host name
is not empty.

Obtained from:	FreeBSD