### PR TITLE
Fix typo when assign r_addr on fetch_socket_tok

### DIFF
--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3430,7 +3430,7 @@ fetch_socket_tok(tokenstr_t *tok, u_char *buf, int len)
 	if (err)
 		return (-1);
 
-	READ_TOKEN_BYTES(buf, len, &tok->tt.socket.l_addr,
+	READ_TOKEN_BYTES(buf, len, &tok->tt.socket.r_addr,
 	    sizeof(tok->tt.socket.r_addr), tok->len, err);
 	if (err)
 		return (-1);


### PR DESCRIPTION
I found a tiny bug when fetching socket token.
I am pretty sure this line should be _r_addr_ not _l_addr_.

Thank you