### PR TITLE
auditreduce: add a zone filter

### DIFF
--- a/bin/auditreduce/auditreduce.1
+++ b/bin/auditreduce/auditreduce.1
@@ -25,7 +25,7 @@
 .\" IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 .\" POSSIBILITY OF SUCH DAMAGE.
 .\"
-.Dd January 24, 2004
+.Dd February 20, 2020
 .Dt AUDITREDUCE 1
 .Os
 .Sh NAME
@@ -47,6 +47,7 @@
 .Op Fl r Ar ruid
 .Op Fl u Ar auid
 .Op Fl v
+.Op Fl z Ar zone
 .Op Ar
 .Sh DESCRIPTION
 The
@@ -129,6 +130,10 @@ Select records with the given real user ID or name.
 Select records with the given audit ID.
 .It Fl v
 Invert sense of matching, to select records that do not match.
+.It Fl z Ar zone
+Select records from the given zone(s).
+.Ar zone
+is a glob for zones to match.
 .El
 .Sh EXAMPLES
 To select all records associated with effective user ID root from the audit

--- a/bin/auditreduce/auditreduce.h
+++ b/bin/auditreduce/auditreduce.h
@@ -57,6 +57,7 @@ struct re_entry {
 #define OPT_u	0x00010000
 #define OPT_A	0x00020000
 #define OPT_v	0x00040000
+#define OPT_z	0x00080000
 
 #define FILEOBJ "file"
 #define MSGQIDOBJ "msgqid"


### PR DESCRIPTION
This adds a -z argument to select records matching the given zone name.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>
Sponsored by:	Modirum MDPay, Klara Systems