### PR TITLE
Introduce au_set_eventdb_fd() interface

### DIFF
--- a/bin/auditreduce/auditreduce.c
+++ b/bin/auditreduce/auditreduce.c
@@ -649,6 +649,7 @@ main(int argc, char **argv)
 #ifdef HAVE_CAP_ENTER
 	int retval, status;
 	pid_t childpid, pid;
+	int fd;
 #endif
 
 	converr = NULL;
@@ -820,6 +821,15 @@ main(int argc, char **argv)
 	argv += optind;
 	argc -= optind;
 
+#ifdef HAVE_CAP_ENTER
+        fd = open(AUDIT_EVENT_FILE, O_RDONLY);
+        if (fd == -1) {
+                err(1, "failed to get file descriptor for event db");
+        }
+        if (au_set_eventdb_fd(fd) != 0) {
+		errx(1, "failed to initialize event db file descriptor");
+	}
+#endif
 	if (argc == 0) {
 #ifdef HAVE_CAP_ENTER
 		retval = cap_enter();

--- a/bsm/libbsm.h
+++ b/bsm/libbsm.h
@@ -861,6 +861,7 @@ int			 au_strtopol(const char *polstr, int *policy);
 /*
  * Functions relating to querying audit event information.
  */
+int			 au_set_eventdb_fd(int);
 void			 setauevent(void);
 void			 endauevent(void);
 struct au_event_ent	*getauevent(void);

--- a/libbsm/bsm_event.c
+++ b/libbsm/bsm_event.c
@@ -57,6 +57,26 @@ static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 #endif
 
 /*
+ * Expose an interface to allow consumers of this library running inside a
+ * capsisum sandbox to set the file descriptor for the event database. Currently
+ * we assume read only access.
+ *
+ * NB: locking? Currently this pointer is not under mutex scope.
+ */
+int
+au_set_eventdb_fd(int fd)
+{
+	FILE *event_fp;
+
+	event_fp = fdopen(fd, "r");
+	if (event_fp == NULL) {
+		return (-1);
+	}
+	fp = event_fp;
+	return (0);
+}
+
+/*
  * Parse one line from the audit_event file into the au_event_ent structure.
  */
 static struct au_event_ent *


### PR DESCRIPTION
auditreduce runs inside a capsicum sandbox, which means certain types
of filtering will fail if they require file descriptors to the event
or class databases. Introduce au_set_eventdb_fd() which allows capsicum
consumers of libbsm to specify which file descriptor should be used for
the event database.

Teach auditreduce to use this function. Note we might scope it down and
grab the file descriptor only if -c is specified. But this is a humble
begining for now

Documentation to come.

Reported by: @ltning
Issue: https://github.com/openbsm/openbsm/issues/66