### PR TITLE
Update OpenBSM constants with recent additions by Apple

### DIFF
--- a/sys/bsm/audit_errno.h
+++ b/sys/bsm/audit_errno.h
@@ -161,6 +161,7 @@
 #define	BSM_ERRNO_EALREADY		149
 #define	BSM_ERRNO_EINPROGRESS		150
 #define	BSM_ERRNO_ESTALE		151
+#define	BSM_ERRNO_EQFULL		152
 
 /*
  * OpenBSM constants for error numbers not defined in Solaris.  In the event

--- a/sys/bsm/audit_fcntl.h
+++ b/sys/bsm/audit_fcntl.h
@@ -111,6 +111,10 @@
 #define	BSM_F_CHECK_OPENEVT	358	/* Darwin-specific. */
 #define	BSM_F_ADDSIGS		359	/* Darwin-specific. */
 #define	BSM_F_MARKDEPENDENCY	360	/* Darwin-specific. */
+#define	BSM_F_BARRIERFSYNC	361	/* Darwin-specific. */
+#define	BSM_F_PUNCHHOLE		362	/* Darwin-specific. */
+#define	BSM_F_TRIM_ACTIVE_FILE	363	/* Darwin-specific. */
+#define	BSM_F_SPECULATIVE_READ	364	/* Darwin-specific. */
 
 /*
  * Darwin file system specific (400-499).

--- a/sys/bsm/audit_kevents.h
+++ b/sys/bsm/audit_kevents.h
@@ -445,6 +445,7 @@
 #define	AUE_PIDFORTASK		43049	/* Darwin-specific. */
 #define	AUE_SYSCTL_NONADMIN	43050
 #define	AUE_COPYFILE		43051	/* Darwin-specific. */
+#define	AUE_DBGPORTFORPID	43052   /* Darwin-specific. */
 
 /*
  * Events added to OpenBSM for FreeBSD and Linux; may also be used by Darwin
@@ -656,6 +657,11 @@
 #define	AUE_REALPATHAT		43264	/* FreeBSD-specific. */
 #define	AUE_CLOSERANGE		43265	/* FreeBSD-specific. */
 
+#define	AUE_SESSION_START	44901   /* Darwin. */
+#define	AUE_SESSION_UPDATE	44902   /* Darwin. */
+#define	AUE_SESSION_END		44903   /* Darwin. */
+#define	AUE_SESSION_CLOSE	44904   /* Darwin. */
+
 /*
  * Darwin BSM uses a number of AUE_O_* definitions, which are aliased to the
  * normal Solaris BSM identifiers.  _O_ refers to it being an old, or compat
@@ -840,5 +846,11 @@
 #define	AUE_WATCHEVENT		AUE_NULL
 #define	AUE_WORKQOPEN		AUE_NULL
 #define	AUE_WORKQOPS		AUE_NULL
+#define	AUE_WORKLOOPCTL		AUE_NULL
+#define	AUE_PERSONA		AUE_NULL
+#define	AUE_USRCTL		AUE_NULL
+#define	AUE_NEXUS		AUE_NULL
+#define	AUE_CHANNEL		AUE_NULL
+#define	AUE_NET			AUE_NULL
 
 #endif /* !_BSM_AUDIT_KEVENTS_H_ */

--- a/sys/bsm/audit_record.h
+++ b/sys/bsm/audit_record.h
@@ -132,6 +132,11 @@
 #define	AUT_ARG_UUID		0x84		/* UUID of argument object */
 #define	AUT_RETURN_UUID		0x85		/* UUID of returned object */
 
+/* Apple specific tokens */
+#define	AUT_IDENTITY		0xed
+#define	AUT_KRB5_PRINCIPAL	0xee
+#define	AUT_CERT_HASH		0xef
+
 /* print values for the arbitrary token */
 #define AUP_BINARY      0
 #define AUP_OCTAL       1


### PR DESCRIPTION
- This update the OpenBSM constants withe additions from
  xnu-6153.11.26 (macOS 10.15.0)

- A FreeBSD differential can be found at https://reviews.freebsd.org/D23572