### PR TITLE
Update OpenBSM constants from FreeBSD 14-CURRENT

### DIFF
--- a/sys/bsm/audit_kevents.h
+++ b/sys/bsm/audit_kevents.h
@@ -656,6 +656,9 @@
 #define	AUE_SHMRENAME		43263	/* FreeBSD-specific. */
 #define	AUE_REALPATHAT		43264	/* FreeBSD-specific. */
 #define	AUE_CLOSERANGE		43265	/* FreeBSD-specific. */
+#define	AUE_SPECIALFD		43266   /* FreeBSD-specific. */
+#define	AUE_AIO_WRITEV		43267   /* FreeBSD-specific. */
+#define	AUE_AIO_READV		43268   /* FreeBSD-specific. */
 
 #define	AUE_SESSION_START	44901   /* Darwin. */
 #define	AUE_SESSION_UPDATE	44902   /* Darwin. */


### PR DESCRIPTION
- Add new constants defined in audit_kevents.h on FreeBSD 13-CURRENT