### PR TITLE
closefrom: fix off-by-one error

### DIFF
--- a/compat/closefrom.h
+++ b/compat/closefrom.h
@@ -41,8 +41,8 @@ closefrom(int lowfd)
 
 	maxfd = sysconf(_SC_OPEN_MAX);
 	if (maxfd < 0)
-		maxfd = 16384;
-	for (fd = lowfd; fd <= maxfd; fd++)
+		maxfd = 16385;
+	for (fd = lowfd; fd < maxfd; fd++)
 		(void)close(fd);
 
 	errno = error;


### PR DESCRIPTION
_SC_OPEN_MAX is documented as "One more than the maximum value the
system may assign to a new file descriptor".

Adapt fallback to respect that rule too.