### PR TITLE
Remove "All rights reserved" from FreeBSD Foundation copyrights

### DIFF
--- a/bin/auditdistd/auditdistd.8
+++ b/bin/auditdistd/auditdistd.8
@@ -1,5 +1,4 @@
 .\" Copyright (c) 2012 The FreeBSD Foundation
-.\" All rights reserved.
 .\"
 .\" This documentation was written by Pawel Jakub Dawidek under sponsorship
 .\" from the FreeBSD Foundation.

--- a/bin/auditdistd/auditdistd.c
+++ b/bin/auditdistd/auditdistd.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/auditdistd.conf.5
+++ b/bin/auditdistd/auditdistd.conf.5
@@ -1,5 +1,4 @@
 .\" Copyright (c) 2012 The FreeBSD Foundation
-.\" All rights reserved.
 .\"
 .\" This documentation was written by Pawel Jakub Dawidek under sponsorship
 .\" from the FreeBSD Foundation.

--- a/bin/auditdistd/auditdistd.h
+++ b/bin/auditdistd/auditdistd.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/faccessat.h
+++ b/bin/auditdistd/faccessat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/fstatat.h
+++ b/bin/auditdistd/fstatat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/openat.h
+++ b/bin/auditdistd/openat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/parse.y
+++ b/bin/auditdistd/parse.y
@@ -1,7 +1,6 @@
 %{
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/pjdlog.c
+++ b/bin/auditdistd/pjdlog.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
  * Copyright (c) 2011 Pawel Jakub Dawidek <pjd@FreeBSD.org>
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/pjdlog.h
+++ b/bin/auditdistd/pjdlog.h
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
  * Copyright (c) 2011 Pawel Jakub Dawidek <pjd@FreeBSD.org>
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto.c
+++ b/bin/auditdistd/proto.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto.h
+++ b/bin/auditdistd/proto.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_common.c
+++ b/bin/auditdistd/proto_common.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
  * Copyright (c) 2011 Pawel Jakub Dawidek <pawel@dawidek.net>
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_impl.h
+++ b/bin/auditdistd/proto_impl.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_socketpair.c
+++ b/bin/auditdistd/proto_socketpair.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_tcp.c
+++ b/bin/auditdistd/proto_tcp.c
@@ -1,7 +1,6 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
  * Copyright (c) 2011 Pawel Jakub Dawidek <pawel@dawidek.net>
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_tls.c
+++ b/bin/auditdistd/proto_tls.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2011 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/proto_uds.c
+++ b/bin/auditdistd/proto_uds.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/receiver.c
+++ b/bin/auditdistd/receiver.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/renameat.h
+++ b/bin/auditdistd/renameat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/sandbox.c
+++ b/bin/auditdistd/sandbox.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/sandbox.h
+++ b/bin/auditdistd/sandbox.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/sender.c
+++ b/bin/auditdistd/sender.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/sigtimedwait.h
+++ b/bin/auditdistd/sigtimedwait.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/strndup.h
+++ b/bin/auditdistd/strndup.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/synch.h
+++ b/bin/auditdistd/synch.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2009-2010 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/token.l
+++ b/bin/auditdistd/token.l
@@ -1,7 +1,6 @@
 %{
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/trail.c
+++ b/bin/auditdistd/trail.c
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/trail.h
+++ b/bin/auditdistd/trail.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/bin/auditdistd/unlinkat.h
+++ b/bin/auditdistd/unlinkat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/compat/closefrom.h
+++ b/compat/closefrom.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.

--- a/compat/compat.h
+++ b/compat/compat.h
@@ -1,6 +1,5 @@
 /*-
  * Copyright (c) 2012 The FreeBSD Foundation
- * All rights reserved.
  *
  * This software was developed by Pawel Jakub Dawidek under sponsorship from
  * the FreeBSD Foundation.


### PR DESCRIPTION
It no longer serves any real purpose, and has been removed from the default FreeBSD project and FreeBSD Foundation license text.