### PR TITLE
fix free() in au_read_rec error case

### DIFF
--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -4763,7 +4763,7 @@ au_read_rec(FILE *fp, u_char **buf)
 
 		if (fread(bptr, 1, ntohs(filenamelen), fp) <
 		    ntohs(filenamelen)) {
-			free(buf);
+			free(*buf);
 			errno = EINVAL;
 			return (-1);
 		}


### PR DESCRIPTION
buf is a char ** and *buf is the allocated buffer. Reported by Robert Morris in FreeBSD PR 267050.

Fixes: 34be9e68e250 ("Teach au_read_rec() to recognize file...")