### PR TITLE
libbsm: honour AU_OFLAG_NORESOLVE

### DIFF
--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -653,7 +653,7 @@ print_user(FILE *fp, u_int32_t usr, int oflags)
 {
 	struct passwd *pwent;
 
-	if (oflags & AU_OFLAG_RAW)
+	if (oflags & (AU_OFLAG_RAW | AU_OFLAG_NORESOLVE))
 		fprintf(fp, "%d", usr);
 	else {
 		pwent = getpwuid(usr);
@@ -672,7 +672,7 @@ print_group(FILE *fp, u_int32_t grp, int oflags)
 {
 	struct group *grpent;
 
-	if (oflags & AU_OFLAG_RAW)
+	if (oflags & (AU_OFLAG_RAW | AU_OFLAG_NORESOLVE))
 		fprintf(fp, "%d", grp);
 	else {
 		grpent = getgrgid(grp);


### PR DESCRIPTION
AU_OFLAG_NORESOLVE is documented as "Leave user and group IDs in their numeric form" but it was not actually tested.

Reported in FreeBSD PR 282271.