### PR TITLE
libbsm: fix memory safety bugs in BSM token parsers

### DIFF
--- a/bsm/libbsm.h
+++ b/bsm/libbsm.h
@@ -620,12 +620,18 @@ typedef struct {
 } au_socketinet32_t;
 
 /*
+ * Largest sun_path across all supported platforms (Linux and Solaris use 108,
+ * macOS and FreeBSD use 104).
+ */
+#define	AU_UNIX_PATH_MAX	108
+
+/*
  * socket family           2 bytes
- * path                    104 bytes
+ * path                    up to AU_UNIX_PATH_MAX bytes + NUL
  */
 typedef struct {
 	u_int16_t	family;
-	char		path[104];
+	char		path[AU_UNIX_PATH_MAX];
 } au_socketunix_t;
 
 /*

--- a/bsm/libbsm.h
+++ b/bsm/libbsm.h
@@ -627,7 +627,7 @@ typedef struct {
 
 /*
  * socket family           2 bytes
- * path                    up to AU_UNIX_PATH_MAX bytes + NUL
+ * path                    up to AU_UNIX_PATH_MAX bytes (NUL terminated)
  */
 typedef struct {
 	u_int16_t	family;

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3401,10 +3401,7 @@ fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 	remaining = (size_t)(len - (int)tok->len);
 	search = remaining < pathmax ? remaining : pathmax;
 	p = (u_char *)memchr((const void *)(buf + tok->len), '\0', search);
-	slen = (p ? (int)(p - (buf + tok->len)) : (int)pathmax - 1) + 1;
-	if (slen > (int)pathmax) {
-		slen = (int)pathmax;
-	}
+	slen = (p ? (int)(p - (buf + tok->len)) + 1 : (int)search);
 
 	READ_TOKEN_BYTES(buf, len, tok->tt.sockunix.path, slen, tok->len, err);
 	if (err)

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -1948,6 +1948,15 @@ fetch_execarg_tok(tokenstr_t *tok, u_char *buf, int len)
 		return (-1);
 
 	for (i = 0; i < tok->tt.execarg.count; i++) {
+		/*
+		 * Make sure that tok->len has not reached the end of the
+		 * buffer. If the previous string's nul byte was the last byte
+		 * in the buffer, the nul accounting below will have set
+		 * tok->len == len, leaving no room for another string.
+		 */
+		if (tok->len >= (u_int32_t)len) {
+			return (-1);
+		}
 		bptr = buf + tok->len;
 		if (i < AUDIT_MAX_ARGS)
 			tok->tt.execarg.text[i] = (char*)bptr;
@@ -2006,6 +2015,15 @@ fetch_execenv_tok(tokenstr_t *tok, u_char *buf, int len)
 		return (-1);
 
 	for (i = 0; i < tok->tt.execenv.count; i++) {
+		/*
+		 * Make sure that tok->len has not reached the end of the
+		 * buffer. If the previous string's nul byte was the last byte
+		 * in the buffer, the nul accounting below will have set
+		 * tok->len == len, leaving no room for another string.
+		 */
+		if (tok->len >= (u_int32_t)len) {
+			return (-1);
+		}
 		bptr = buf + tok->len;
 		if (i < AUDIT_MAX_ENV)
 			tok->tt.execenv.text[i] = (char*)bptr;
@@ -2118,6 +2136,17 @@ fetch_newgroups_tok(tokenstr_t *tok, u_char *buf, int len)
 	if (err)
 		return (-1);
 
+	/*
+	 * grps.list[] is statically sized and set to AUDIT_MAX_GROUPS. If the
+	 * group count specified in the record is greater than this value just
+	 * clamp/truncate it. Silently truncating a malformed record changes
+	 * what was recorded and could mask tampering. However, a precedent
+	 * has been set in fetch_execarg_tok and fetch_execenv_tok which
+	 * truncate the count under similar circumstances.
+	 */
+	if (tok->tt.grps.no > AUDIT_MAX_GROUPS) {
+		tok->tt.grps.no = AUDIT_MAX_GROUPS;
+	}
 	for (i = 0; i<tok->tt.grps.no; i++) {
 		READ_TOKEN_U_INT32(buf, len, tok->tt.grps.list[i], tok->len,
 		    err);
@@ -3357,15 +3386,30 @@ fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 	int err = 0;
 	u_char *p;
 	int slen;
-
+	size_t remaining, search;
 
 	READ_TOKEN_U_INT16(buf, len, tok->tt.sockunix.family, tok->len, err);
 	if (err)
 		return (-1);
 
-	/* slen = strnlen((buf + tok->len), 104) + 1; */
-	p = (u_char *)memchr((const void *)(buf + tok->len), '\0', 104);
-	slen = (p ? (int)(p - (buf + tok->len))  : 104) + 1;
+	/*
+	 * Make sure we clamp the search length to at most the number of bytes
+	 * that are remaining in the buffer after we subtract the current
+	 * value of tok->len (3 at this point: 1 byte for the token type and
+	 * 2 for the socket address family). Also make sure it's no more than
+	 * 104 bytes.
+	 */
+	remaining = (size_t)(len - (int)tok->len);
+	search = remaining < 104 ? remaining : 104;
+	p = (u_char *)memchr((const void *)(buf + tok->len), '\0', search);
+	slen = (p ? (int)(p - (buf + tok->len)) : 104) + 1;
+	/*
+	 * If a nul byte was not found the resulting calculation for slen above
+	 * will end up being 105 which will result in a 1 byte overflow.
+	 */
+	if (slen > (int)sizeof(tok->tt.sockunix.path)) {
+		slen = (int)sizeof(tok->tt.sockunix.path);
+	}
 
 	READ_TOKEN_BYTES(buf, len, tok->tt.sockunix.path, slen, tok->len, err);
 	if (err)
@@ -3430,7 +3474,7 @@ fetch_socket_tok(tokenstr_t *tok, u_char *buf, int len)
 	if (err)
 		return (-1);
 
-	READ_TOKEN_BYTES(buf, len, &tok->tt.socket.l_addr,
+	READ_TOKEN_BYTES(buf, len, &tok->tt.socket.r_addr,
 	    sizeof(tok->tt.socket.r_addr), tok->len, err);
 	if (err)
 		return (-1);

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3383,10 +3383,10 @@ print_sock_inet128_tok(FILE *fp, tokenstr_t *tok, char *del, int oflags)
 static int
 fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 {
+	size_t remaining, search;
 	int err = 0;
 	u_char *p;
 	int slen;
-	size_t remaining, search;
 
 	READ_TOKEN_U_INT16(buf, len, tok->tt.sockunix.family, tok->len, err);
 	if (err)

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3378,12 +3378,12 @@ print_sock_inet128_tok(FILE *fp, tokenstr_t *tok, char *del, int oflags)
 
 /*
  * socket family           2 bytes
- * path                    (up to) 104 bytes + NULL (NULL terminated string).
+ * path                    (up to) AU_UNIX_PATH_MAX bytes + NUL
  */
 static int
 fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 {
-	size_t remaining, search;
+	size_t remaining, search, pathmax;
 	int err = 0;
 	u_char *p;
 	int slen;
@@ -3393,23 +3393,17 @@ fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 		return (-1);
 
 	/*
-	 * Make sure we clamp the search length to at most the number of bytes
-	 * that are remaining in the buffer after we subtract the current
-	 * value of tok->len (3 at this point: 1 byte for the token type and
-	 * 2 for the socket address family). Also make sure it's no more than
-	 * 104 bytes.
+	 * Clamp the search to the bytes remaining in the token and the path
+	 * storage size.  Using sizeof(tok->tt.sockunix.path) rather than a
+	 * literal keeps the bound in sync with au_socketunix_t automatically.
 	 */
+	pathmax = sizeof(tok->tt.sockunix.path);
 	remaining = (size_t)(len - (int)tok->len);
-	search = remaining < 104 ? remaining : 104;
+	search = remaining < pathmax ? remaining : pathmax;
 	p = (u_char *)memchr((const void *)(buf + tok->len), '\0', search);
-	slen = (p ? (int)(p - (buf + tok->len)) : 104) + 1;
-	/*
-	 * If a nul byte was not found the resulting calculation for slen above
-	 * will end up being 105 which will result in a 1 byte overflow.
-	 */
-	if (slen > (int)sizeof(tok->tt.sockunix.path)) {
-		slen = (int)sizeof(tok->tt.sockunix.path);
-	}
+	slen = (p ? (int)(p - (buf + tok->len)) : (int)pathmax - 1) + 1;
+	if (slen > (int)pathmax)
+		slen = (int)pathmax;
 
 	READ_TOKEN_BYTES(buf, len, tok->tt.sockunix.path, slen, tok->len, err);
 	if (err)

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3409,6 +3409,8 @@ fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 	READ_TOKEN_BYTES(buf, len, tok->tt.sockunix.path, slen, tok->len, err);
 	if (err)
 		return (-1);
+	/* guarantee NUL termination when no NUL was found in the token data */
+	tok->tt.sockunix.path[pathmax - 1] = '\0';
 
 	return (0);
 }

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3378,7 +3378,7 @@ print_sock_inet128_tok(FILE *fp, tokenstr_t *tok, char *del, int oflags)
 
 /*
  * socket family           2 bytes
- * path                    (up to) AU_UNIX_PATH_MAX bytes + NUL
+ * path                    (up to) AU_UNIX_PATH_MAX bytes (NUL terminated)
  */
 static int
 fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)

--- a/libbsm/bsm_io.c
+++ b/libbsm/bsm_io.c
@@ -3402,8 +3402,9 @@ fetch_sock_unix_tok(tokenstr_t *tok, u_char *buf, int len)
 	search = remaining < pathmax ? remaining : pathmax;
 	p = (u_char *)memchr((const void *)(buf + tok->len), '\0', search);
 	slen = (p ? (int)(p - (buf + tok->len)) : (int)pathmax - 1) + 1;
-	if (slen > (int)pathmax)
+	if (slen > (int)pathmax) {
 		slen = (int)pathmax;
+	}
 
 	READ_TOKEN_BYTES(buf, len, tok->tt.sockunix.path, slen, tok->len, err);
 	if (err)

--- a/libbsm/bsm_token.c
+++ b/libbsm/bsm_token.c
@@ -1133,7 +1133,7 @@ au_to_socket_ex(u_short so_domain, u_short so_type,
 /*
  * token ID                1 byte
  * socket family           2 bytes
- * path                    (up to) 104 bytes + NULL  (NULL terminated string)
+ * path                    (up to) AU_UNIX_PATH_MAX bytes + NUL
  */
 token_t *
 au_to_sock_unix(struct sockaddr_un *so)

--- a/libbsm/bsm_token.c
+++ b/libbsm/bsm_token.c
@@ -1133,7 +1133,7 @@ au_to_socket_ex(u_short so_domain, u_short so_type,
 /*
  * token ID                1 byte
  * socket family           2 bytes
- * path                    (up to) AU_UNIX_PATH_MAX bytes + NUL
+ * path                    (up to) AU_UNIX_PATH_MAX bytes (NUL terminated)
  */
 token_t *
 au_to_sock_unix(struct sockaddr_un *so)


### PR DESCRIPTION
`fetch_newgroups_tok(3)`: clamp group count to `AUDIT_MAX_GROUPS` before the loop to prevent a stack buffer overflow when a crafted record specifies more than 16 groups.

`fetch_execarg_tok(3)`, `fetch_execenv_tok(3)`: add a bounds check at the top of the string-walking loop to prevent an out-of-bounds read when the previous string's nul byte is the last byte of the record buffer.

`fetch_sock_unix_tok(3)`: clamp the memchr search length to the number of bytes remaining in the buffer to prevent an out-of-bounds read on short tokens. Also clamp slen to sizeof(path) to prevent a one-byte overflow when no nul byte is found within the path data.

fetch_socket_tok: fix copy-paste error where the remote address was written into `l_addr` instead of `r_addr`.
Previously reported by: @haginara

Define `AU_UNIX_PATH_MAX` as `108` (the largest sun_path across all supported platforms) and use it in `au_socketunix_t` instead of the hardcoded 104.

Update `fetch_sock_unix_tok` to derive its search bound from `sizeof(tok->tt.sockunix.path)` so cross-platform records from Solaris and Linux with paths up to 108 bytes parse correctly without truncation.