### PR TITLE
Fix endian issue with auditing port numbers

### DIFF
--- a/libbsm/bsm_token.c
+++ b/libbsm/bsm_token.c
@@ -1211,7 +1211,7 @@ au_to_sock_inet128(struct sockaddr_in6 *so)
 	ADD_U_CHAR(dptr, 0);
 	ADD_U_CHAR(dptr, so->sin6_family);
 
-	ADD_U_INT16(dptr, so->sin6_port);
+	ADD_MEM(dptr, &so->sin6_port, sizeof(uint16_t));
 	ADD_MEM(dptr, &so->sin6_addr, 4 * sizeof(uint32_t));
 
 	return (t);


### PR DESCRIPTION
`ADD_U_INT16()` calls `be16enc()`, which assumes the input value is in host byte order and converts it to big-endian. However, `sin6_port` is already stored in network byte order (big-endian). On a little-endian system (like x86 or ARM), the CPU interprets those bytes as a byte-swapped integer, and then `be16enc()` swaps them again.

Use `ADD_MEM()` here instead which is basically just a memcpy that will preserve the correct network byte order.

Submitted by:	Drew  Gallatin
Differential revision: https://reviews.freebsd.org/D39633#1293388